### PR TITLE
Fix missing prefix exception on the layout tab

### DIFF
--- a/Model/View/Renderer/LayoutGraphRenderer.php
+++ b/Model/View/Renderer/LayoutGraphRenderer.php
@@ -79,7 +79,8 @@ class LayoutGraphRenderer implements RendererInterface
                 $nodes[] = $this->layoutNodeFactory->create([
                     'block' => $block,
                     'layoutRenderTime' => $this->totalRenderTime,
-                    'children' => $children
+                    'children' => $children,
+                    'prefix' => ''
                 ]);
             }
         }


### PR DESCRIPTION
Fixes "Missing required argument $prefix of ClawRock\Debug\Model\ValueObject\LayoutNode."

Details to reproduce:
- Profile a page with the Layout profiling enabled. 
- Navigate to the performance profile page and click the layout tab