### PR TITLE
fix: graphql session disabled

### DIFF
--- a/Model/Info/RequestInfo.php
+++ b/Model/Info/RequestInfo.php
@@ -134,7 +134,7 @@ class RequestInfo
      */
     public function getSessionAttributes(): array
     {
-        return $_SESSION; // phpcs:ignore Magento2.Security.Superglobal.SuperglobalUsageError
+        return session_status() ? $_SESSION : []; // phpcs:ignore Magento2.Security.Superglobal.SuperglobalUsageError
     }
 
     public function getPathInfo(): string


### PR DESCRIPTION
Solves #13. When `graphql/session/disable` is set to `1` the `$_SESSION` variable does not exist.