### PR TITLE
Handle when the allowed ip addresses are empty

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -97,10 +97,12 @@ class Config
 
     public function getAllowedIPs(): array
     {
-        return array_filter(array_map('trim', explode(',', (string) $this->scopeConfig->getValue(
-            self::CONFIG_ALLOWED_IPS,
-            ScopeConfigInterface::SCOPE_TYPE_DEFAULT
-        ))));
+        $value = $this->scopeConfig->getValue(self::CONFIG_ALLOWED_IPS, ScopeConfigInterface::SCOPE_TYPE_DEFAULT);
+        if(empty($value))
+        {
+            return [];
+        }
+        return array_filter(array_map('trim', explode(',', $value)));
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "filp/whoops": "^2.1",
         "jdorn/sql-formatter": "^1.2",
         "symfony/var-dumper": "*",
-        "symfony/stopwatch": "^2.8 || ^3.0 || ^4.0 || ^5.0"
+        "symfony/stopwatch": "^2.8 || ^3.0 || ^4.0 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "bitexpert/phpstan-magento": "^0.30.0",


### PR DESCRIPTION
Magento 2.4.8 (on PHP 8.4) returns null instead of empty string when the value is empty. This leads to an exception. So instead of passing the value directly to the explode method I return an empty array if the options are empty.