### PR TITLE
Update dependency list, add hyva compat fix

### DIFF
--- a/Plugin/UseMagentoBackendThemeOnDebugFrontendViewPlugin.php
+++ b/Plugin/UseMagentoBackendThemeOnDebugFrontendViewPlugin.php
@@ -7,6 +7,7 @@ namespace ClawRock\Debug\Plugin;
 use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\App\Area;
 use Magento\Framework\Controller\ResultInterface;
+
 class UseMagentoBackendThemeOnDebugFrontendViewPlugin
 {
     private string $currentTheme = '';

--- a/Plugin/UseMagentoBackendThemeOnDebugFrontendViewPlugin.php
+++ b/Plugin/UseMagentoBackendThemeOnDebugFrontendViewPlugin.php
@@ -1,12 +1,15 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ClawRock\Debug\Plugin;
 
+use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\App\Area;
-
+use Magento\Framework\Controller\ResultInterface;
 class UseMagentoBackendThemeOnDebugFrontendViewPlugin
 {
+    private string $currentTheme = '';
     public function __construct(
         private \Magento\Framework\View\DesignInterface $design
     ) {
@@ -14,7 +17,16 @@ class UseMagentoBackendThemeOnDebugFrontendViewPlugin
 
     public function beforeExecute(): void
     {
+        $this->currentTheme = $this->design->getDesignTheme()->getThemePath();
         $this->design->setArea(Area::AREA_ADMINHTML);
         $this->design->setDesignTheme('Magento/backend');
+    }
+
+    public function afterExecute(HttpGetActionInterface $subject, ?ResultInterface $result): ?ResultInterface
+    {
+        $this->design->setArea(Area::AREA_FRONTEND);
+        $this->design->setDesignTheme($this->currentTheme);
+
+        return $result;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "filp/whoops": "^2.1",
         "jdorn/sql-formatter": "^1.2",
         "symfony/var-dumper": "*",
-        "symfony/stopwatch": "^2.8 || ^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0"
+        "symfony/stopwatch": "^2.8 || ^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0"
     },
     "require-dev": {
         "bitexpert/phpstan-magento": "^0.30.0",


### PR DESCRIPTION
I am working on a few tweaks for this awesome tool, these first 2 are ones that we needed to do to get it working on our projects.

1. Update allowed range of stopwatch installs
2. Add hyva compat fix to ensure the theme is reset

The profiler worked okay on the frontend load but when we clicked through to view data it failed with a hyvaCsp error, i'm guessing something with the way its injected didnt like the theme fiddling back to admin.

By capturing and resetting the theme at the end we can view all the debug data
<img width="489" height="116" alt="Screenshot 2026-06-29 at 17 15 39" src="https://github.com/user-attachments/assets/9a1b4ed2-c6ff-4fd1-941d-1adebc9a5105" />
